### PR TITLE
Support of mp4 files encoding using libopenh264 for H.264 codec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.tar.xz
 *.tar.gz
 .*.swp
+.vscode/
 
 ffmpeg-*/
 lame-*/
@@ -8,6 +9,7 @@ libogg-*/
 libvorbis-*/
 libvpx-*/
 opus-*/
+openh264-*/
 
 tests/out.ogg
 tests/out.opus

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ clean: halfclean
 	-rm -rf libogg-$(LIBOGG_VERSION)
 	-rm -rf libvpx-$(LIBVPX_VERSION)
 	-rm -rf lame-$(LAME_VERSION)
+	-rm -rf openh264-$(OPENH264_VERSION)
 	-rm -rf ffmpeg-$(FFMPEG_VERSION)
 
 distclean: clean
@@ -112,6 +113,7 @@ distclean: clean
 	-rm -f libogg-$(LIBOGG_VERSION).tar.xz
 	-rm -f libvpx-$(LIBVPX_VERSION).tar.gz
 	-rm -f lame-$(LAME_VERSION).tar.gz
+	-rm -rf openh264-$(OPENH264_VERSION).tar.gz
 	-rm -f ffmpeg-$(FFMPEG_VERSION).tar.xz
 
 .PRECIOUS: libav-$(LIBAVJS_VERSION)-%.wasm.js libav-$(LIBAVJS_VERSION)-%.asm.js ffmpeg-$(FFMPEG_VERSION)/build-%/ffmpeg ffmpeg-$(FFMPEG_VERSION)/build-%/ffbuild/config.mak

--- a/configs/fragments/mp4/ffmpeg-config.txt
+++ b/configs/fragments/mp4/ffmpeg-config.txt
@@ -1,2 +1,0 @@
---enable-demuxer=mp4
---enable-muxer=mp4

--- a/configs/fragments/mp4/ffmpeg-config.txt
+++ b/configs/fragments/mp4/ffmpeg-config.txt
@@ -1,0 +1,2 @@
+--enable-demuxer=mp4
+--enable-muxer=mp4

--- a/configs/fragments/openh264/deps.txt
+++ b/configs/fragments/openh264/deps.txt
@@ -1,0 +1,1 @@
+tmp-inst/lib/pkgconfig/openh264.pc

--- a/configs/fragments/openh264/ffmpeg-config.txt
+++ b/configs/fragments/openh264/ffmpeg-config.txt
@@ -1,0 +1,5 @@
+--enable-libopenh264
+--enable-muxer=mp4
+--enable-decoder=libopenh264
+--enable-encoder=libopenh264
+

--- a/configs/fragments/openh264/libs.txt
+++ b/configs/fragments/openh264/libs.txt
@@ -1,0 +1,1 @@
+tmp-inst/lib/libopenh264.a

--- a/configs/fragments/openh264/license.js
+++ b/configs/fragments/openh264/license.js
@@ -1,0 +1,31 @@
+ *
+ * ---
+ *
+ * libopenh264:
+ *
+ * Copyright (c) 2013, Cisco Systems
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * 
+ * * Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *

--- a/configs/fragments/openh264/link-flags.txt
+++ b/configs/fragments/openh264/link-flags.txt
@@ -1,0 +1,1 @@
+-lstdc++ -lm -lpthread -s ERROR_ON_UNDEFINED_SYMBOLS=0

--- a/mk/ffmpeg.mk
+++ b/mk/ffmpeg.mk
@@ -10,11 +10,14 @@ ffmpeg-$(FFMPEG_VERSION)/build-%/ffbuild/config.mak: ffmpeg-$(FFMPEG_VERSION)/PA
 	cd ffmpeg-$(FFMPEG_VERSION)/build-$* ; \
 	emconfigure env PKG_CONFIG_PATH="$(PWD)/tmp-inst/lib/pkgconfig" \
 		../configure --prefix=/opt/ffmpeg \
+		--target-os=linux \
 		--cc=emcc --ranlib=emranlib \
 		--extra-cflags="-I$(PWD)/tmp-inst/include" \
 		--extra-ldflags="-L$(PWD)/tmp-inst/lib" \
 		--arch=emscripten --enable-small --disable-doc \
 		--disable-stripping --disable-pthreads \
+		--disable-programs \
+		--disable-ffplay --disable-ffprobe --disable-network --disable-iconv --disable-xlib \
 		--disable-sdl2 \
 		--disable-everything \
 		`cat ../../configs/$*/ffmpeg-config.txt`

--- a/mk/openh264.mk
+++ b/mk/openh264.mk
@@ -1,0 +1,17 @@
+OPENH264_VERSION=2.2.0
+
+tmp-inst/lib/pkgconfig/openh264.pc: openh264-$(OPENH264_VERSION)/PATCHED
+	cd openh264-$(OPENH264_VERSION) ; \
+		emmake $(MAKE) install-static OS=linux \
+		ARCH=mips CFLAGS="-O3 -fno-stack-protector" PREFIX=$(PWD)/tmp-inst
+
+openh264-$(OPENH264_VERSION)/PATCHED: openh264-$(OPENH264_VERSION).tar.gz
+	tar zxf openh264-$(OPENH264_VERSION).tar.gz
+	cd openh264-$(OPENH264_VERSION) ; patch -p1 -i ../patches/openh264.diff
+	touch openh264-$(OPENH264_VERSION)/PATCHED
+
+openh264-$(OPENH264_VERSION).tar.gz:
+	curl https://github.com/cisco/openh264/archive/refs/tags/v$(OPENH264_VERSION).tar.gz -L -o $@
+
+openh264-release:
+	cp openh264-$(OPENH264_VERSION).tar.gz libav.js-$(LIBAVJS_VERSION)/sources/

--- a/patches/ffmpeg.diff
+++ b/patches/ffmpeg.diff
@@ -114,3 +114,14 @@ index a456c3d..a604699 100644
  
      /* CRC is correct so we can be 99% sure there's an actual change here */
      if (idx < 0) {
+--- a/libavcodec/libopenh264enc.c	2021-10-04 00:08:29.000000000 +0530
++++ b/libavcodec/libopenh264enc.c	2022-06-21 18:34:22.000000000 +0530
+@@ -377,7 +377,7 @@
+     sp.iPicHeight = avctx->height;
+ 
+     if (frame->pict_type == AV_PICTURE_TYPE_I) {
+-        (*s->encoder)->ForceIntraFrame(s->encoder, true);
++        (*s->encoder)->ForceIntraFrame(s->encoder, true, -1);
+     }
+ 
+     encoded = (*s->encoder)->EncodeFrame(s->encoder, &sp, &fbi);

--- a/patches/openh264.diff
+++ b/patches/openh264.diff
@@ -1,0 +1,11 @@
+--- a/codec/api/svc/codec_api.h	2022-01-28 10:27:33.000000000 +0530
++++ b/codec/api/svc/codec_api.h	2022-06-21 18:32:08.000000000 +0530
+@@ -486,7 +486,7 @@
+ int (*EncodeFrame) (ISVCEncoder*, const SSourcePicture* kpSrcPic, SFrameBSInfo* pBsInfo);
+ int (*EncodeParameterSets) (ISVCEncoder*, SFrameBSInfo* pBsInfo);
+ 
+-int (*ForceIntraFrame) (ISVCEncoder*, bool bIDR);
++int (*ForceIntraFrame) (ISVCEncoder*, bool bIDR, int iLayerId);
+ 
+ int (*SetOption) (ISVCEncoder*, ENCODER_OPTION eOptionId, void* pOption);
+ int (*GetOption) (ISVCEncoder*, ENCODER_OPTION eOptionId, void* pOption);


### PR DESCRIPTION
1) Added two fragments libopenh264 and mp4 to support mp4 files.
2) Disabled building some programs which were not needed.

[libopenh264](https://github.com/cisco/openh264): BSD 2-Clause "Simplified" License [LICENCE](https://github.com/cisco/openh264/blob/master/LICENSE) 