### PR TITLE
Some LibAV Factory Function Options were Missing

### DIFF
--- a/libav.types.in.d.ts
+++ b/libav.types.in.d.ts
@@ -327,6 +327,9 @@ export interface LibAVWrapper {
      */
     LibAV(opts?: {
         noworker?: boolean,
-        nowasm?: boolean
+        nowasm?: boolean,
+        nosimd?: boolean,
+        yesthreads?: boolean,
+        nothreads?: boolean,
     }): Promise<LibAV>;
 }


### PR DESCRIPTION
Maybe these are intended to be undocumented? They are definitely hooked up, merge this if it was just missed