### PR TITLE
Missing type signatures on Freers

### DIFF
--- a/apply-funcs.js
+++ b/apply-funcs.js
@@ -152,7 +152,7 @@ function decls(f, meta) {
     });
 
     funcs.freers.forEach((decl) => {
-        outp += `${decl}_js(ptr: number);\n`;
+        outp += `${decl}_js(ptr: number): Promise<void>;\n`;
     });
 
     funcs.copiers.forEach((type) => {


### PR DESCRIPTION
Assuming these are async, this I think is correct.