### PR TITLE
Add a Dockerfile.development to supply a buildenv

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,7 @@
+# syntax = docker/dockerfile:1.2
+FROM emscripten/emsdk
+
+ARG ENV
+
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y pkg-config
+# This dockerfile supplies a perfect building environment, e.g. to be used with VS code


### PR DESCRIPTION
Since it took me a while to set up a working build environment, I have made a Dockerfile.development for e.g. VS Code and others, that may aid others to faster start building and contributing faster. 