### PR TITLE
Fix loading code on safari

### DIFF
--- a/pre.js
+++ b/pre.js
@@ -15,7 +15,7 @@
 
 Module.locateFile = function(path, prefix) {
     // if it's the wasm file
-    if (path.indexOf(".wasm") === path.length - 5 &&
+    if (path.lastIndexOf(".wasm") === path.length - 5 &&
         path.indexOf("libav-") !== -1) {
         // Consider using an overridden wasm URL
         var gt;


### PR DESCRIPTION
On safari the wasm file, which is loaded ends with `.wasm.wasm` and causes the old code to fail. So actually lastIndexOf is the correct search pattern.