### PR TITLE
Fix: ff_decode_filter_multi was Missing from funcs.json

### DIFF
--- a/funcs.json
+++ b/funcs.json
@@ -172,6 +172,7 @@
         "ff_read_multi",
         "ff_init_filter_graph",
         "ff_filter_multi",
+        "ff_decode_filter_multi",
         "ff_copyout_frame",
         "ff_copyout_frame_video",
         "ff_frame_video_packed_size",


### PR DESCRIPTION
I'm not sure if there other missed functions in funcs.json, but without this change `ff_decoder_filter_multi` didn't exist on the libav instance.