### PR TITLE
Bugfix/js functions use single pointer options

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -515,20 +515,22 @@ AVFormatContext *avformat_alloc_output_context2_js(AVOutputFormat *oformat,
 }
 
 AVFormatContext *avformat_open_input_js(const char *url, AVInputFormat *fmt,
-    AVDictionary **options)
+    AVDictionary *options)
 {
     AVFormatContext *ret = NULL;
-    int err = avformat_open_input(&ret, url, fmt, options);
+    AVDictionary** options_p = &options;
+    int err = avformat_open_input(&ret, url, fmt, options_p);
     if (err < 0)
         fprintf(stderr, "[avformat_open_input_js] %s\n", av_err2str(err));
     return ret;
 }
 
 AVIOContext *avio_open2_js(const char *url, int flags,
-    const AVIOInterruptCB *int_cb, AVDictionary **options)
+    const AVIOInterruptCB *int_cb, AVDictionary *options)
 {
     AVIOContext *ret = NULL;
-    int err = avio_open2(&ret, url, flags, int_cb, options);
+    AVDictionary** options_p = &options;
+    int err = avio_open2(&ret, url, flags, int_cb, options_p);
     if (err < 0)
         fprintf(stderr, "[avio_open2_js] %s\n", av_err2str(err));
     return ret;

--- a/tests/tests/500-demux-decode.js
+++ b/tests/tests/500-demux-decode.js
@@ -180,8 +180,9 @@ async function main()
     src_filename = "bbb.mp4";
 
     /* open input file, and allocate format context */
+    const options = await libav.av_dict_set_js(0, "foobar", "123");
     fmt_ctx = await
-        libav.avformat_open_input_js(src_filename, 0, 0);
+        libav.avformat_open_input_js(src_filename, 0, options);
     if (!fmt_ctx) {
         throw new Error(
             "Could not open source file");


### PR DESCRIPTION
As discussed in #34 , this PR patches both `av_dict_set_js` and `avio_open2_js` to accept a `AVDictionary*` rather than a `AVDictionary **` (since the JS code only exposed `AVDictionary*`).

Note that this does mean that `av_dict_set_js` will not be able to return a list of unused options (as ffmpeg's `av_dict_set` does).

I changed the `500-demuxer-decode` test to include some arbitrary options dictionary. This test will fail without the code change, since free will be called on something that is not a pointer.