### PR TITLE
add loglevel constants to types.d.ts

### DIFF
--- a/libav.types.in.d.ts
+++ b/libav.types.in.d.ts
@@ -385,6 +385,15 @@ export interface LibAV {
     AVDISCARD_NONINTRA: number;
     AVDISCARD_NONKEY: number;
     AVDISCARD_ALL: number;
+    AV_LOG_QUIET: number;
+    AV_LOG_PANIC: number;
+    AV_LOG_FATAL: number;
+    AV_LOG_ERROR: number;
+    AV_LOG_WARNING: number;
+    AV_LOG_INFO: number;
+    AV_LOG_VERBOSE: number;
+    AV_LOG_DEBUG: number;
+    AV_LOG_TRACE: number;
     E2BIG: number;
     EPERM: number;
     EADDRINUSE: number;


### PR DESCRIPTION
Fix for #39 added loglevel support, however didn't add the constants to types.d.ts