### PR TITLE
Fix `LibAV()` overload for typescript.

### DIFF
--- a/libav.types.in.d.ts
+++ b/libav.types.in.d.ts
@@ -511,4 +511,5 @@ export interface LibAVWrapper {
      */
     LibAV(opts?: LibAVOpts & {noworker?: false}): Promise<LibAV>;
     LibAV(opts: LibAVOpts & {noworker: true}): Promise<LibAV & LibAVSync>;
+    LibAV(opts: LibAVOpts): Promise<LibAV | LibAV & LibAVSync>;
 }


### PR DESCRIPTION
Typescript's overload system is [no smart
enough](https://www.typescriptlang.org/docs/handbook/2/functions.html#writing-good-overloads) to realise that if a function overload exists for two types, the function can also be called on the union of those two types.

Therefore if only the following is defined:

```ts
LibAV(opts?: LibAVOpts & {noworker?: false}): Promise<LibAV>;
LibAV(opts: LibAVOpts & {noworker: true}): Promise<LibAV & LibAVSync>;
```

the following call will fail:

```ts
let opts: LibAVOpts = ...
const libav = LibAV.LibAV(opts)
```

I'm not 100% satisfied with this solution, and there might be some way to fix it with generics, but I didn't manage. The solution was tested on all code below (none of my other solutions worked for all 5 cases):

```ts
const _libav0 = await window.LibAV.LibAV()
const _libav1 = await window.LibAV.LibAV({})
const _libav2 = await window.LibAV.LibAV({noworker: false})
const _libav3 = await window.LibAV.LibAV({noworker: true})
const _libav4 = await window.LibAV.LibAV(libavoptions as LibAVOpts)
```