### PR TITLE
Add AV_PKT_FLAG_* constants

### DIFF
--- a/libav.in.js
+++ b/libav.in.js
@@ -196,6 +196,14 @@
     libavStatics.AV_LOG_DEBUG = 48;
     libavStatics.AV_LOG_TRACE = 56;
 
+     // AV_PKT_FLAGs
+     ret.AV_PKT_FLAG_KEY = 0x0001;
+     ret.AV_PKT_FLAG_CORRUPT = 0x0002;
+     ret.AV_PKT_FLAG_DISCARD = 0x0004;
+     ret.AV_PKT_FLAG_TRUSTED = 0x0008;
+     ret.AV_PKT_FLAG_DISPOSABLE = 0x0010;
+
+
     // Errors
     enume(["E2BIG", "EPERM", "EADDRINUSE", "EADDRNOTAVAIL",
         "EAFNOSUPPORT", "EAGAIN", "EALREADY", "EBADF", "EBADMSG",

--- a/libav.types.in.d.ts
+++ b/libav.types.in.d.ts
@@ -344,6 +344,11 @@ export interface LibAVStatic {
     AV_LOG_VERBOSE: number;
     AV_LOG_DEBUG: number;
     AV_LOG_TRACE: number;
+    AV_PKT_FLAG_KEY: number;
+    AV_PKT_FLAG_CORRUPT: number;
+    AV_PKT_FLAG_DISCARD: number;
+    AV_PKT_FLAG_TRUSTED: number;
+    AV_PKT_FLAG_DISPOSABLE: number;
     E2BIG: number;
     EPERM: number;
     EADDRINUSE: number;


### PR DESCRIPTION
I see they're being used in the bridge, and I find them useful myself