### PR TITLE
fixes for threaded libav.js when building with newer emsdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ EFLAGS=\
 	--post-js build/post.js --extern-post-js extern-post.js \
 	-s "EXPORT_NAME='LibAVFactory'" \
 	-s "EXPORTED_FUNCTIONS=@build/exports.json" \
-	-s "EXPORTED_RUNTIME_METHODS=['cwrap']" \
+	-s "EXPORTED_RUNTIME_METHODS=['cwrap', 'PThread']" \
 	-s MODULARIZE=1 \
 	-s STACK_SIZE=1048576 \
 	-s ASYNCIFY \

--- a/Makefile.m4
+++ b/Makefile.m4
@@ -20,7 +20,7 @@ EFLAGS=\
 	--post-js build/post.js --extern-post-js extern-post.js \
 	-s "EXPORT_NAME='LibAVFactory'" \
 	-s "EXPORTED_FUNCTIONS=@build/exports.json" \
-	-s "EXPORTED_RUNTIME_METHODS=['cwrap']" \
+	-s "EXPORTED_RUNTIME_METHODS=['cwrap', 'PThread']" \
 	-s MODULARIZE=1 \
 	-s STACK_SIZE=1048576 \
 	-s ASYNCIFY \

--- a/extern-post.js
+++ b/extern-post.js
@@ -18,7 +18,10 @@ if (/* We're in a worker */
     /* We're not being loaded with noworker from the main code */
     typeof LibAV === "undefined" &&
     /* We're not being loaded as a thread */
-    typeof Module === "undefined"
+    (
+        (typeof self === "undefined" && typeof Module === "undefined")
+        || self.name !== "em-pthread"
+    )
     ) (function() {
     var libav;
 


### PR DESCRIPTION
When building with emsdk >= 3.1.58, the resulting built file hangs when you instantiate it with `yesthreads` set to `true`.

This fixes that, and also another problem.