### PR TITLE
Add missing type for `unlinkreadaheadfile()` function

### DIFF
--- a/post.in.js
+++ b/post.in.js
@@ -426,6 +426,7 @@ Module.mkreadaheadfile = function(name, file) {
  * Unlink a readahead file. Also gets rid of the File reference.
  * @param name  Filename to unlink.
  */
+/// @types unlinkreadaheadfile@sync(name: string): @promise@void@
 Module.unlinkreadaheadfile = function(name) {
     FS.unlink(name);
     delete readaheads[name];


### PR DESCRIPTION
When creating readahead files I noticed that there's no type for unlink function, because TypeScript complained about it not being there, despite actually existing & being mentioned in I/O docs.

This pull request adds the missing type to `post.in.js`.