### PR TITLE
Fix broken type exports

### DIFF
--- a/package-one-variant.json
+++ b/package-one-variant.json
@@ -7,7 +7,7 @@
   "exports": {
     "import": "./dist/libav-@VARIANT.mjs",
     "default": "./dist/libav-@VARIANT.js",
-    "types": "dist/libav.types.d.ts"
+    "types": "./dist/libav.types.d.ts"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION
TypeScript dies if the path is not a proper relative path