### PR TITLE
expose av_seek_frame

### DIFF
--- a/funcs.json
+++ b/funcs.json
@@ -73,6 +73,7 @@
         ["avformat_new_stream", "number", ["number", "number"]],
         ["avformat_open_input", "number", ["number", "string", "number", "number"], {"async": true, "returnsErrno": true}],
         ["avformat_open_input_js", "number", ["string", "number", "number"], {"async": true, "returnsErrno": true}],
+        ["av_seek_frame", "number", ["number", "number", "number", "number"], {"async": true, "returnsErrno": true, "notypes": true}],
         ["avformat_seek_file", "number", ["number", "number", "number", "number", "number", "number"], {"async": true, "returnsErrno": true, "notypes": true}],
         ["avformat_seek_file_min", "number", ["number", "number", "number", "number"], {"async": true, "returnsErrno": true, "notypes": true}],
         ["avformat_seek_file_max", "number", ["number", "number", "number", "number"], {"async": true, "returnsErrno": true, "notypes": true}],

--- a/libav.types.in.d.ts
+++ b/libav.types.in.d.ts
@@ -605,6 +605,14 @@ export interface LibAV extends LibAVStatic {
     ): Promise<number>;
 
     /**
+     * Seek to the keyframe at timestamp.
+     */
+    av_seek_frame(
+        s: number, stream_index: number, tslo: number, tshi: number,
+        flags: number
+    ): Promise<number>;
+
+    /**
      * Get the depth of this component of this pixel format.
      */
     AVPixFmtDescriptor_comp_depth(fmt: number, comp: number): Promise<number>;

--- a/tests/tests/615-seek.js
+++ b/tests/tests/615-seek.js
@@ -55,6 +55,10 @@ await libav.avformat_seek_file_approx(fmt_ctx, 0,
     3.5 * 60 * streams[0].time_base_den / streams[0].time_base_num, 0,
     0);
 await testSeek(3 * 60, 4 * 60, "avformat_seek_file_approx");
+await libav.av_seek_frame(fmt_ctx, 0,
+    3.5 * 60 * streams[0].time_base_den / streams[0].time_base_num, 0,
+    0);
+await testSeek(3 * 60, 4 * 60, "av_seek_frame");
 
 await libav.av_packet_free_js(pkt);
 await libav.avformat_close_input_js(fmt_ctx);


### PR DESCRIPTION
Hello! Thank you for this project. 

I'm replicating functionality of this project https://github.com/Streampunk/beamcoder in browser.
this lib uses av_seek_frame here https://github.com/Streampunk/beamcoder/blob/master/src/demux.cc#L345
which works a little bit different from avformat_seek_file
I have exported it in my own custom build, but I wanted to ask is any chance to get it in official build?