### PR TITLE
Codecpar coded_side_data

### DIFF
--- a/funcs.json
+++ b/funcs.json
@@ -135,7 +135,8 @@
             ["AVPacketSideData_size", "number", ["number", "number"]],
             ["AVPacketSideData_type", "number", ["number", "number"]],
             ["av_packet_unref", null, ["number"]],
-            ["av_shrink_packet", null, ["number", "number"]]
+            ["av_shrink_packet", null, ["number", "number"]],
+            ["ff_codecpar_new_side_data", "number", ["number", "number", "number"]]
         ],
 
         "meta": [
@@ -163,6 +164,7 @@
                 "codec_id",
                 "codec_tag",
                 "codec_type",
+                "coded_side_data",
                 "color_primaries",
                 "color_range",
                 "color_space",
@@ -173,6 +175,7 @@
                 {"name": "framerate", "rational": true},
                 "height",
                 "level",
+                "nb_coded_side_data",
                 "profile",
                 "sample_rate",
                 "width"
@@ -378,6 +381,7 @@
                 "channels",
                 "channel_layoutmask",
                 "ch_layout_nb_channels",
+                "coded_side_data",
                 "compression_level",
                 "extradata",
                 "extradata_size",
@@ -388,6 +392,7 @@
                 "keyint_min",
                 "level",
                 "max_b_frames",
+                "nb_coded_side_data",
                 "pix_fmt",
                 "profile",
                 "rc_max_rate",

--- a/funcs.json
+++ b/funcs.json
@@ -39,7 +39,8 @@
             ["av_opt_set_int_list_js", "number", ["number", "string", "number", "number", "number", "number"]],
             ["av_strdup", "number", ["string"]],
             ["ff_error", "string", ["number"]],
-            ["ff_nothing", null, [], {"async": true}]
+            ["ff_nothing", null, [], {"async": true}],
+            ["LIBAVUTIL_VERSION_INT", "number", []]
         ],
 
         "freers": [
@@ -136,7 +137,8 @@
             ["AVPacketSideData_type", "number", ["number", "number"]],
             ["av_packet_unref", null, ["number"]],
             ["av_shrink_packet", null, ["number", "number"]],
-            ["ff_codecpar_new_side_data", "number", ["number", "number", "number"]]
+            ["ff_codecpar_new_side_data", "number", ["number", "number", "number"]],
+            ["LIBAVCODEC_VERSION_INT", "number", []]
         ],
 
         "meta": [
@@ -264,7 +266,8 @@
             ["av_read_frame", "number", ["number", "number"], {"async": true, "returnsErrno": true}],
             ["av_seek_frame", "number", ["number", "number", "number", "number"], {"async": true, "returnsErrno": true, "notypes": true}],
             ["av_write_frame", "number", ["number", "number"]],
-            ["av_write_trailer", "number", ["number"]]
+            ["av_write_trailer", "number", ["number"]],
+            ["LIBAVFORMAT_VERSION_INT", "number", []]
         ],
 
         "fs": [
@@ -435,7 +438,8 @@
             ["avfilter_graph_parse", "number", ["number", "string", "number", "number", "number"]],
             ["avfilter_inout_alloc", "number", []],
             ["avfilter_inout_free", null, ["number"]],
-            ["avfilter_link", "number", ["number", "number", "number", "number"]]
+            ["avfilter_link", "number", ["number", "number", "number", "number"]],
+            ["LIBAVFILTER_VERSION_INT", "number", []]
         ],
 
         "meta": [

--- a/src/b-avcodec.c
+++ b/src/b-avcodec.c
@@ -33,15 +33,17 @@ B(enum AVMediaType, type)
 B(enum AVCodecID, codec_id)
 B(enum AVMediaType, codec_type)
 BL(int64_t, bit_rate)
+B(AVPacketSideData *, coded_side_data)
+B(int, compression_level)
 B(uint8_t *, extradata)
 B(int, extradata_size)
-B(int, compression_level)
 B(int, frame_size)
 B(int, gop_size)
 B(int, height)
 B(int, keyint_min)
 B(int, level)
 B(int, max_b_frames)
+B(int, nb_coded_side_data)
 B(int, pix_fmt)
 B(int, profile)
 BL(int64_t, rc_max_rate)
@@ -93,6 +95,16 @@ B(enum AVColorTransferCharacteristic, color_trc)
 B(enum AVColorSpace, color_space)
 B(enum AVChromaLocation, chroma_location)
 B(int, sample_rate)
+
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(60, 30, 100)
+B(AVPacketSideData *, coded_side_data)
+B(int, nb_coded_side_data)
+#else
+AVPacketSideData *AVCodecParameters_coded_side_data(AVCodecParameters *a) { return NULL; }
+void AVCodecParameters_coded_side_data_s(AVCodecParameters *a, AVPacketSideData *b) {}
+int AVCodecParameters_nb_coded_side_data(AVCodecParameters *a) { return 0; }
+void AVCodecParameters_nb_coded_side_data_s(AVCodecParameters *a, AVPacketSideData *b) {}
+#endif
 #undef B
 
 #if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(60, 10, 100)
@@ -102,6 +114,20 @@ RAT_FAKE(AVCodecParameters, framerate, 60, 1)
 #endif
 
 CHL(AVCodecParameters)
+
+uint8_t *ff_codecpar_new_side_data(
+    AVCodecParameters *codecpar, enum AVPacketSideDataType type, size_t size
+) {
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(60, 30, 100)
+    AVPacketSideData *sd = av_packet_side_data_new(
+        &codecpar->coded_side_data, &codecpar->nb_coded_side_data, type, size,
+        0
+    );
+    return sd ? sd->data : NULL;
+#else
+    return NULL;
+#endif
+}
 
 
 /* AVPacket */

--- a/src/b-avcodec.c
+++ b/src/b-avcodec.c
@@ -184,3 +184,7 @@ void av_packet_rescale_ts_js(
                tb_dst = {tb_dst_num, tb_dst_den};
     av_packet_rescale_ts(pkt, tb_src, tb_dst);
 }
+
+static const int LIBAVCODEC_VERSION_INT_V = LIBAVCODEC_VERSION_INT;
+#undef LIBAVCODEC_VERSION_INT
+int LIBAVCODEC_VERSION_INT() { return LIBAVCODEC_VERSION_INT_V; }

--- a/src/b-avfilter.c
+++ b/src/b-avfilter.c
@@ -56,3 +56,7 @@ AVFilterContext *avfilter_graph_create_filter_js(const AVFilter *filt,
         fprintf(stderr, "[avfilter_graph_create_filter_js] %s\n", av_err2str(err));
     return ret;
 }
+
+static const int LIBAVFILTER_VERSION_INT_V = LIBAVFILTER_VERSION_INT;
+#undef LIBAVFILTER_VERSION_INT
+int LIBAVFILTER_VERSION_INT() { return LIBAVFILTER_VERSION_INT_V; }

--- a/src/b-avformat.c
+++ b/src/b-avformat.c
@@ -88,3 +88,7 @@ AVIOContext *avio_open2_js(const char *url, int flags,
         fprintf(stderr, "[avio_open2_js] %s\n", av_err2str(err));
     return ret;
 }
+
+static const int LIBAVFORMAT_VERSION_INT_V = LIBAVFORMAT_VERSION_INT;
+#undef LIBAVFORMAT_VERSION_INT
+int LIBAVFORMAT_VERSION_INT() { return LIBAVFORMAT_VERSION_INT_V; }

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -329,3 +329,7 @@ int mallinfo_uordblks()
 {
     return mallinfo().uordblks;
 }
+
+static const int LIBAVUTIL_VERSION_INT_V = LIBAVUTIL_VERSION_INT;
+#undef LIBAVUTIL_VERSION_INT
+int LIBAVUTIL_VERSION_INT() { return LIBAVUTIL_VERSION_INT_V; }

--- a/src/frontend.in.js
+++ b/src/frontend.in.js
@@ -146,6 +146,10 @@
         }
     };
 
+    libavStatics.AV_VERSION_INT = function(maj, min, rev) {
+        return maj << 16 | min << 8 | rev;
+    };
+
     // Some enumerations lifted directly from FFmpeg
     function enume(vals, first) {
         if (typeof first === undefined)

--- a/src/libav.types.in.d.ts
+++ b/src/libav.types.in.d.ts
@@ -432,6 +432,14 @@ declare namespace LibAV {
             channels?: number
         }): number;
 
+        /**
+         * Convert a major, minor, and revision number to the internal integer
+         * version representation used in libav. Note that these version numbers
+         * are *not* FFmpeg versions. They are the internal libav versions, one
+         * for each libav library.
+         */
+        AV_VERSION_INT(maj: number, min: number, rev: number): number;
+
         // Constants:
         AV_NOPTS_VALUE_I64: [number, number];
         AV_NOPTS_VALUE_LO: number;

--- a/src/libav.types.in.d.ts
+++ b/src/libav.types.in.d.ts
@@ -277,6 +277,11 @@ declare namespace LibAV {
          */
         channel_layoutmask?: number;
         channels?: number;
+
+        /**
+         * Side data. Codec-specific.
+         */
+        coded_side_data?: any;
     }
 
     /**


### PR DESCRIPTION
Will resolve #89 

Also fixes some minor issues with `side_data` in packets, and exposes version numbers so that users can choose where to put side data.