### PR TITLE
fix: resolve type check comparison bug in enume helper in frontend.in.js

### DIFF
--- a/src/frontend.in.js
+++ b/src/frontend.in.js
@@ -152,7 +152,7 @@
 
     // Some enumerations lifted directly from FFmpeg
     function enume(vals, first) {
-        if (typeof first === undefined)
+        if (typeof first === "undefined")
             first = 0;
         var i = first;
         vals.forEach(function(val) {
@@ -415,7 +415,7 @@
                             ret.worker.postMessage(msg, transfer);
                         });
                     };
-                    function onworkermessage(e) {
+                    function onworkermessage(e) { 
                         var id = e.data[0];
                         var h = ret.handlers[id];
                         if (h) {
@@ -556,7 +556,7 @@
 
             }
 
-        }).then(function() {
+        }).then(function() { 
             // Step three: Add wrappers to the instance(s)
 
             function indirectors(funcs) {


### PR DESCRIPTION
In `src/frontend.in.js` within the helper function `enume` (which maps FFmpeg enumeration lists to integer values on `libavStatics`), there is a bug where the check for whether the parameter `first` is defined uses `typeof first === undefined`. In JavaScript, the `typeof` operator returns a string (e.g., `"undefined"`), meaning that comparing it against the identifier `undefined` directly (which is not a string) evaluates incorrectly or throws/fails to detect undefined arguments. This fix updates the check to `typeof first === "undefined"` so that it correctly matches the string returned by the `typeof` operator, ensuring proper fallback handling for the enumeration index offset parameter.